### PR TITLE
Added Alire manifest file.

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -1,0 +1,32 @@
+name = "gwindows"
+version = "1.4"
+description = "GWindows - Ada Framework for Windows Development"
+authors = [
+	"David Botton",
+	"Gautier de Montmollin"
+]
+maintainers = [
+	"Felix Patschkowski <felix.patschkowski@nexperia.com>"
+]
+maintainers-logins = [
+	"patschkowski"
+]
+licenses = "LGPL-2.0-or-later"
+project-files = [
+	"gnatcom/gnatcom.gpr",
+	"gnatcom/gnatcom_tools.gpr",
+	"gwindows/gwindows.gpr"
+]
+executables = [
+	"bindcom",
+	"comscope",
+	"createcom",
+	"makeguid"
+]
+
+[available.'case(os)']
+windows = true
+'...' = false
+
+[environment.PATH]
+prepend = "${CRATE_ROOT}/alire/build/gnatcom/tools"


### PR DESCRIPTION
I had to change the license statement because Alire requires now to follow this nomenclature: https://spdx.org/licenses/

With the latest Alire version 1.0.0-rc I can successfully go through the "alr publish", but I not want to use my forked repo for that. I'd prefer to release this crate to Alire from the original Github repo.

Kind regards,
Felix