### PR TITLE
Add Owner_Draw to Status_Bar_Type.

### DIFF
--- a/gwindows/framework/gwindows-common_controls.adb
+++ b/gwindows/framework/gwindows-common_controls.adb
@@ -628,13 +628,15 @@ package body GWindows.Common_Controls is
    is
       SB_SETTEXTA   : constant := 16#401#;
       SB_SETTEXTW   : constant := 16#40B#;
-      SBT_NOBORDERS : constant := 16#100#;
-      SBT_POPOUT    : constant := 16#200#;
+      SBT_NOBORDERS : constant := 16#0100#;
+      SBT_POPOUT    : constant := 16#0200#;
+      SBT_OWNERDRAW : constant := 16#1000#;
 
       Format : constant array (Status_Kind_Type) of Integer :=
-        (Flat   => SBT_NOBORDERS,
-         Sunken => 0,
-         Raised => SBT_POPOUT);
+        (Flat       => SBT_NOBORDERS,
+         Sunken     => 0,
+         Raised     => SBT_POPOUT,
+         Owner_Draw => SBT_OWNERDRAW);
 
       C_Text : GString_C := GWindows.GStrings.To_GString_C (Text);
 

--- a/gwindows/framework/gwindows-common_controls.adb
+++ b/gwindows/framework/gwindows-common_controls.adb
@@ -633,10 +633,10 @@ package body GWindows.Common_Controls is
       SBT_OWNERDRAW : constant := 16#1000#;
 
       Format : constant array (Status_Kind_Type) of Integer :=
-        (Flat       => SBT_NOBORDERS,
-         Sunken     => 0,
-         Raised     => SBT_POPOUT,
-         Owner_Draw => SBT_OWNERDRAW);
+        (Flat        => SBT_NOBORDERS,
+         Sunken      => 0,
+         Raised      => SBT_POPOUT,
+         Owner_Drawn => SBT_OWNERDRAW);
 
       C_Text : GString_C := GWindows.GStrings.To_GString_C (Text);
 

--- a/gwindows/framework/gwindows-common_controls.ads
+++ b/gwindows/framework/gwindows-common_controls.ads
@@ -204,7 +204,7 @@ package GWindows.Common_Controls is
    --  the right edge of the corresponding part extends to the border of
    --  the window
 
-   type Status_Kind_Type is (Flat, Sunken, Raised, Owner_Draw);
+   type Status_Kind_Type is (Flat, Sunken, Raised, Owner_Drawn);
    procedure Text (Bar  : in out Status_Bar_Type;
                    Text : in     GString;
                    Part : in     Natural;

--- a/gwindows/framework/gwindows-common_controls.ads
+++ b/gwindows/framework/gwindows-common_controls.ads
@@ -204,7 +204,7 @@ package GWindows.Common_Controls is
    --  the right edge of the corresponding part extends to the border of
    --  the window
 
-   type Status_Kind_Type is (Flat, Sunken, Raised);
+   type Status_Kind_Type is (Flat, Sunken, Raised, Owner_Draw);
    procedure Text (Bar  : in out Status_Bar_Type;
                    Text : in     GString;
                    Part : in     Natural;


### PR DESCRIPTION
Add `Owner_Draw` to `Status_Kind_Type` to allow `Status_Bar_Type` Items to be owner drawn (with the `Text()` procedure.