### PR TITLE
Colorize MDI Client background color.

### DIFF
--- a/gwindows/framework/gwindows-application.adb
+++ b/gwindows/framework/gwindows-application.adb
@@ -72,8 +72,8 @@ package body GWindows.Application is
    --  Win32 Message Loop Objet
 
    procedure Process_Message
-     (Message :        Pointer_To_MSG;
-      Window  : in out GWindows.Base.Base_Window_Type'Class);
+     (Message :    Pointer_To_MSG;
+      Window  : in GWindows.Base.Base_Window_Type'Class);
    --  Process a message for a message loop
 
    -------------------------------------------------------------------------
@@ -749,8 +749,8 @@ package body GWindows.Application is
    ---------------------
 
    procedure Process_Message
-     (Message :        Pointer_To_MSG;
-      Window  : in out GWindows.Base.Base_Window_Type'Class)
+     (Message :    Pointer_To_MSG;
+      Window  : in GWindows.Base.Base_Window_Type'Class)
    is
       use type GWindows.Types.Handle;
       use type GWindows.Internal.Pointer_To_Keyboard_Control;

--- a/gwindows/framework/gwindows-base.ads
+++ b/gwindows/framework/gwindows-base.ads
@@ -327,6 +327,10 @@ package GWindows.Base is
    --  is true when the window is destroyed the Custom_Data memory
    --  will be deallocated with Free
 
+   procedure MDI_Client_Window_Background_Color
+               (Window : in out Base_Window_Type;
+                Color  : in     GWindows.Colors.Color_Type);
+
    -------------------------------------------------------------------------
    --  Base_Window_Type - Methods
    -------------------------------------------------------------------------
@@ -801,6 +805,16 @@ package GWindows.Base is
    --  GWindows Implementation of Win32 Procedure Call Back
    --  Procedure and Message Dispatch
 
+   function WndProc_MDI_Client
+     (hwnd    : GWindows.Types.Handle;
+      message : Interfaces.C.unsigned;
+      wParam  : GWindows.Types.Wparam;
+      lParam  : GWindows.Types.Lparam)
+     return GWindows.Types.Lresult;
+   pragma Convention (Stdcall, WndProc_MDI_Client);
+   --  GWindows Implementation of Win32 Procedure Call Back
+   --  Procedure and Message Dispatch for MDI_CLient
+
    function WndProc_Control
      (hwnd    : GWindows.Types.Handle;
       message : Interfaces.C.unsigned;
@@ -857,6 +871,8 @@ private
          ParentWindowProc : Windproc_Access              := null;
          haccel           : Types.Handle                 := Types.Null_Handle;
          MDI_Client       : Base_Window_Access           := null;
+         MDI_Client_Background_Color_Sys : Boolean       := True;
+         MDI_Client_Background_Color     : GWindows.Colors.Color_Type;
          Keyboard_Support : Boolean                      := False;
          Is_Control       : Boolean                      := False;
          Last_Focused     : Types.Handle                 := Types.Null_Handle;

--- a/gwindows/framework/gwindows-windows.adb
+++ b/gwindows/framework/gwindows-windows.adb
@@ -3870,9 +3870,14 @@ package body GWindows.Windows is
    procedure Background_Color (Window : in out Window_Type;
                                Color  : in     GWindows.Colors.Color_Type)
    is
+      use type GWindows.Base.Base_Window_Access;
    begin
       Window.Background_Color_Sys := False;
       Window.Background_Color     := Color;
+
+      if Window.MDI_Client_Window /= null then
+         Window.MDI_Client_Window_Background_Color (Color);
+      end if;
    end Background_Color;
 
    function Background_Color (Window : in Window_Type)


### PR DESCRIPTION
Add MDI Client window background colorization.

I don't know why but I had to modify `gwindows-application.adb`.

A dedicated `WndProc_MDI_Client` function is added to manage the `WM_ERASEBKGND ` message.