### PR TITLE
Suppress Tabs control flicker.

### DIFF
--- a/gwindows/framework/gwindows-base.adb
+++ b/gwindows/framework/gwindows-base.adb
@@ -998,6 +998,24 @@ package body GWindows.Base is
               abs (Rect.Bottom - Rect.Top));
    end Size;
 
+   ---------------------------
+   -- Double_Buffered_Paint --
+   ---------------------------
+
+   procedure Double_Buffered_Paint (Window : in out Base_Window_Type;
+                                    State  : in     Boolean)
+   is
+   begin
+      Window.Paint_Is_Double_Buffered := State;
+   end Double_Buffered_Paint;
+
+   function Double_Buffered_Paint (Window : in out Base_Window_Type)
+                                  return Boolean
+   is
+   begin
+      return Window.Paint_Is_Double_Buffered;
+   end Double_Buffered_Paint;
+
    ------------------------
    --  Recommended_Size  --
    ------------------------

--- a/gwindows/framework/gwindows-base.ads
+++ b/gwindows/framework/gwindows-base.ads
@@ -270,6 +270,11 @@ package GWindows.Base is
    function Client_Area_Height (Window : in Base_Window_Type) return Natural;
    --  Height of window
 
+   procedure Double_Buffered_Paint (Window : in out Base_Window_Type;
+                                    State  : in     Boolean);
+   function Double_Buffered_Paint (Window : in out Base_Window_Type) return Boolean;
+   --  State of double buffering management
+
    function Recommended_Size (Window : in Base_Window_Type)
                              return GWindows.Types.Size_Type;
    --  If Window has already been created, returns an ideal size
@@ -889,6 +894,7 @@ private
          Is_Linked        : Boolean                      := False;  --  * AnSp
          --  * AnSp:  Added parameter Procedures to be able to create only
          --  *        a link between a Windows handle and GWindows object.
+         Paint_Is_Double_Buffered : Boolean := False;
 
          --  Event Handlers
          On_Create_Event             : Action_Event          := null;

--- a/gwindows/framework/gwindows-common_controls.ads
+++ b/gwindows/framework/gwindows-common_controls.ads
@@ -1353,6 +1353,12 @@ package GWindows.Common_Controls is
       Return_Value : in out GWindows.Types.Lresult);
    --  Handles Notify Messages
 
+   procedure On_Erase_Background
+     (Control              : in out Tab_Control_Type;
+      Canvas               : in out GWindows.Drawing.Canvas_Type;
+      Area                 : in     GWindows.Types.Rectangle_Type;
+      Call_Default_Handler : in out Event_Call_Default_Handler_Type);
+
    procedure On_Paint
      (Control              : in out Tab_Control_Type;
       Canvas               : in out GWindows.Drawing.Canvas_Type;

--- a/gwindows/framework/gwindows-drawing.adb
+++ b/gwindows/framework/gwindows-drawing.adb
@@ -551,6 +551,20 @@ package body GWindows.Drawing is
       SelectObject;
    end Select_Object;
 
+   procedure Select_Object
+     (Canvas          : in out Canvas_Type;
+      Object          : in     GWindows.Drawing_Objects.Drawing_Object_Type'Class;
+      Previous_Object :    out GWindows.Drawing_Objects.Drawing_Object_Type'Class)
+   is
+      function SelectObject
+        (hDC     : GWindows.Types.Handle := Canvas.HDC;
+         HOBJECT : GWindows.Types.Handle := GWindows.Drawing_Objects.Handle (Object))
+        return GWindows.Types.Handle;
+      pragma Import (StdCall, SelectObject, "SelectObject");
+   begin
+      GWindows.Drawing_Objects.Handle (Previous_Object, SelectObject);
+   end Select_Object;
+
    -------------
    -- Capture --
    -------------
@@ -1389,6 +1403,20 @@ package body GWindows.Drawing is
       SetViewportOrgEx;
    end Viewport_Origin;
 
+   procedure Viewport_Origin (Canvas          : in out Canvas_Type;
+                              X, Y            : in     Integer;
+                              Previous_Origin :    out GWindows.Types.Point_Type)
+   is
+      procedure SetViewportOrgEx
+        (HDC :     GWindows.Types.Handle := Canvas.HDC;
+         X1  :     Integer := X;
+         Y1  :     Integer := Y;
+         LPS : out GWindows.Types.Point_Type);
+      pragma Import (StdCall, SetViewportOrgEx, "SetViewportOrgEx");
+   begin
+      SetViewportOrgEx (LPS => Previous_Origin);
+   end Viewport_Origin;
+
    function Viewport_Origin (Canvas : in Canvas_Type)
                             return GWindows.Types.Point_Type
    is
@@ -1420,6 +1448,20 @@ package body GWindows.Drawing is
       pragma Import (StdCall, OffsetViewportOrgEx, "OffsetViewportOrgEx");
    begin
       OffsetViewportOrgEx;
+   end Offset_Viewport_Origin;
+
+   procedure Offset_Viewport_Origin (Canvas          : in out Canvas_Type;
+                                     DX, DY          : in     Integer;
+                                     Previous_Origin :    out GWindows.Types.Point_Type)
+   is
+      procedure OffsetViewportOrgEx
+        (HDC :     GWindows.Types.Handle := Canvas.HDC;
+         X1  :     Integer := DX;
+         Y1  :     Integer := DY;
+         LPS : out GWindows.Types.Point_Type);
+      pragma Import (StdCall, OffsetViewportOrgEx, "OffsetViewportOrgEx");
+   begin
+      OffsetViewportOrgEx (LPS => Previous_Origin);
    end Offset_Viewport_Origin;
 
    --------------------

--- a/gwindows/framework/gwindows-drawing.ads
+++ b/gwindows/framework/gwindows-drawing.ads
@@ -429,6 +429,12 @@ package GWindows.Drawing is
       Object : in     GWindows.Drawing_Objects.Drawing_Object_Type'Class);
    --  Select a drawing object on to canvas
 
+   procedure Select_Object
+     (Canvas          : in out Canvas_Type;
+      Object          : in     GWindows.Drawing_Objects.Drawing_Object_Type'Class;
+      Previous_Object :    out GWindows.Drawing_Objects.Drawing_Object_Type'Class);
+   --  Select a drawing object on to canvas
+
    function Y_Pixels_Per_Inch (Canvas : in Canvas_Type) return Integer;
    function X_Pixels_Per_Inch (Canvas : in Canvas_Type) return Integer;
    --  Calculates the logical pixels per inch
@@ -528,11 +534,19 @@ package GWindows.Drawing is
    procedure Viewport_Origin (Canvas : in out Canvas_Type;
                               X, Y   : in     Integer);
 
+   procedure Viewport_Origin (Canvas          : in out Canvas_Type;
+                              X, Y            : in     Integer;
+                              Previous_Origin :    out GWindows.Types.Point_Type);
+
    function Viewport_Origin (Canvas : in Canvas_Type)
                             return GWindows.Types.Point_Type;
 
    procedure Offset_Viewport_Origin (Canvas : in out Canvas_Type;
                                      DX, DY : in     Integer);
+
+   procedure Offset_Viewport_Origin (Canvas          : in out Canvas_Type;
+                                     DX, DY          : in     Integer;
+                                     Previous_Origin :    out GWindows.Types.Point_Type);
 
    --  Viewport Origin
 


### PR DESCRIPTION
The Tabs Control flicker is mainly suppressed by not erasing the control background.
The remaining flicker is suppressed by using double buffering when painting.
The double buffering method is made global so it can be used by all controls (and windows). You just need to set a flag with `Control.Double_Buffered_Paint (True)`.
