### PR TITLE
Fix MDI child windows appearance when not expanded.

### DIFF
--- a/gwindows/framework/gwindows-base.ads
+++ b/gwindows/framework/gwindows-base.ads
@@ -878,6 +878,7 @@ private
          MDI_Client       : Base_Window_Access           := null;
          MDI_Client_Background_Color_Sys : Boolean       := True;
          MDI_Client_Background_Color     : GWindows.Colors.Color_Type;
+         MDI_Child_Creation              : Boolean := False;
          Keyboard_Support : Boolean                      := False;
          Is_Control       : Boolean                      := False;
          Last_Focused     : Types.Handle                 := Types.Null_Handle;

--- a/gwindows/framework/gwindows-windows.ads
+++ b/gwindows/framework/gwindows-windows.ads
@@ -264,6 +264,13 @@ package GWindows.Windows is
      return GWindows.Base.Pointer_To_Base_Window_Class;
    --  MDI window
 
+   procedure MDI_Maximize_Window
+     (Window : in Window_Type;
+      Child  : in GWindows.Base.Base_Window_Type'Class);
+   procedure MDI_Restore_Window
+     (Window : in Window_Type;
+      Child  : in GWindows.Base.Base_Window_Type'Class);
+
    procedure Default_Cursor (Window : in out Window_Type;
                              Cursor : in     GWindows.Cursors.Cursor_Type);
    --  Set the default cursor display when mouse is over this Window


### PR DESCRIPTION
With the current MDI child windows display glitch removal algorithm, when child windows are not expanded, switching between windows with MDI system menu or with tabs it is impossible to know which window has the focus. They are all shown as focused.
This PR fixes this issue.
For this, the algorithm is used only when child windows are expanded, else the default windowproc is used. However, there is a corner case when a child window is created.
To fix it, in GWindows.Windows, function Create_MDI_Child, CreateWindowEx is replaced by the recommended WM_MDICREATE message. This message is caught in the MDI client windowproc.