### PR TITLE
Winelib

### DIFF
--- a/gwindows/docs/Winelib.txt
+++ b/gwindows/docs/Winelib.txt
@@ -203,7 +203,7 @@ Framework Callback Changes
   called back through the PE-to-Unix thunk, resulting in a page
   fault (STORAGE_ERROR).
 
-  Three framework callbacks were restructured to avoid this:
+  Five framework callbacks were restructured to avoid this:
 
   1. gwindows-application.adb: Monitor_Enum_Callback
 
@@ -227,7 +227,22 @@ Framework Callback Changes
      passed through the BROWSEINFO.lParam field, which
      SHBrowseForFolder forwards to the callback as lpData.
 
-  All three changes are transparent to callers.  On Windows, the
+  4. gwindows-base.adb: Enum_Proc
+
+     Used by Enumerate_Children (EnumChildWindows).  The callback
+     received LPARAM typed as Enumerate_Function (access-to-
+     procedure), but the PE-to-Unix thunk passes it as a raw
+     integer.  Changed LPARAM parameter to GWindows.Types.Lparam
+     and converted with Unchecked_Conversion.
+
+  5. gwindows-enum_emf.adb: Enum_Func
+
+     Used by Enumerate_EMF (EnumEnhMetaFile).  Same issue as #4:
+     EMF_Enum_Proc (access-to-procedure) was passed as lpData
+     and received back through the PE thunk.  Changed to
+     GWindows.Types.Lparam with Unchecked_Conversion.
+
+  All five changes are transparent to callers.  On Windows, the
   restructured callbacks work identically (package-level functions
   with ms_abi are harmless when ms_abi is already the default).
 

--- a/gwindows/framework/gwindows-base.adb
+++ b/gwindows/framework/gwindows-base.adb
@@ -1967,20 +1967,24 @@ package body GWindows.Base is
    -------------------------
 
    function Enum_Proc (hwnd   : GWindows.Types.Handle;
-                       lparam : Enumerate_Function)
+                       lparam : GWindows.Types.Lparam)
                       return Boolean;
    pragma Convention (StdCall, Enum_Proc);
    pragma Machine_Attribute (Enum_Proc, "ms_abi");
 
    function Enum_Proc (hwnd   : GWindows.Types.Handle;
-                       lparam : Enumerate_Function)
+                       lparam : GWindows.Types.Lparam)
                       return Boolean
    is
+      function To_Enumerate_Function is
+        new Ada.Unchecked_Conversion (GWindows.Types.Lparam,
+                                      Enumerate_Function);
+      Proc    : constant Enumerate_Function := To_Enumerate_Function (lparam);
       Win_Ptr : constant Pointer_To_Base_Window_Class :=
         Window_From_Handle (hwnd);
    begin
       if Win_Ptr /= null then
-         lparam (Win_Ptr);
+         Proc (Win_Ptr);
       end if;
       return True;
    end Enum_Proc;
@@ -1988,13 +1992,16 @@ package body GWindows.Base is
    procedure Enumerate_Children (Window : in Base_Window_Type;
                                  Proc   : in Enumerate_Function)
    is
+      function To_Lparam is
+        new Ada.Unchecked_Conversion (Enumerate_Function,
+                                      GWindows.Types.Lparam);
       procedure EnumChildWindows (hwnd   : GWindows.Types.Handle;
                                   Proc   : System.Address;
-                                  lparam : Enumerate_Function);
+                                  lparam : GWindows.Types.Lparam);
       pragma Import (StdCall, EnumChildWindows, "EnumChildWindows");
-   pragma Machine_Attribute (EnumChildWindows, "ms_abi");
+      pragma Machine_Attribute (EnumChildWindows, "ms_abi");
    begin
-      EnumChildWindows (Window.HWND, Enum_Proc'Address, Proc);
+      EnumChildWindows (Window.HWND, Enum_Proc'Address, To_Lparam (Proc));
    end Enumerate_Children;
 
    ---------------

--- a/gwindows/framework/gwindows-base.adb
+++ b/gwindows/framework/gwindows-base.adb
@@ -1968,13 +1968,13 @@ package body GWindows.Base is
 
    function Enum_Proc (hwnd   : GWindows.Types.Handle;
                        lparam : GWindows.Types.Lparam)
-                      return Boolean;
+                      return Interfaces.C.int;
    pragma Convention (StdCall, Enum_Proc);
    pragma Machine_Attribute (Enum_Proc, "ms_abi");
 
    function Enum_Proc (hwnd   : GWindows.Types.Handle;
                        lparam : GWindows.Types.Lparam)
-                      return Boolean
+                      return Interfaces.C.int
    is
       function To_Enumerate_Function is
         new Ada.Unchecked_Conversion (GWindows.Types.Lparam,
@@ -1986,7 +1986,7 @@ package body GWindows.Base is
       if Win_Ptr /= null then
          Proc (Win_Ptr);
       end if;
-      return True;
+      return 1;
    end Enum_Proc;
 
    procedure Enumerate_Children (Window : in Base_Window_Type;

--- a/gwindows/framework/gwindows-enum_emf.adb
+++ b/gwindows/framework/gwindows-enum_emf.adb
@@ -1,3 +1,4 @@
+with Ada.Unchecked_Conversion;
 with GWindows.GStrings; use GWindows.GStrings;
 
 package body GWindows.Enum_EMF is
@@ -7,7 +8,7 @@ package body GWindows.Enum_EMF is
                 lpHTable : Handle_Table_Access;
                 lpEMFR   : PEMR_Type;
                 nObj     : Integer;
-                lpData   : EMF_Enum_Proc) return Integer;
+                lpData   : GWindows.Types.Lparam) return Integer;
    pragma Convention (Stdcall, ENHMFENUMPROC);
    pragma Machine_Attribute (ENHMFENUMPROC, "ms_abi");
    type Prectangle_Type is access GWindows.Types.Rectangle_Type;
@@ -15,7 +16,7 @@ package body GWindows.Enum_EMF is
    function EnumEnhMetaFile (hdc           : GWindows.Types.Handle;
                              HENHMETAFILE  : GWindows.Types.Handle;
                              lpEnhMetaFunc : ENHMFENUMPROC;
-                             lpData        : EMF_Enum_Proc;
+                             lpData        : GWindows.Types.Lparam;
                              lpRect        : Prectangle_Type) return Integer;
    pragma Import (StdCall, EnumEnhMetaFile, "EnumEnhMetaFile");
    pragma Machine_Attribute (EnumEnhMetaFile, "ms_abi");
@@ -24,17 +25,20 @@ package body GWindows.Enum_EMF is
                        lpHTable : Handle_Table_Access;
                        lpEMFR   : PEMR_Type;
                        nObj     : Integer;
-                       lpData   : EMF_Enum_Proc) return Integer;
+                       lpData   : GWindows.Types.Lparam) return Integer;
    pragma Convention (Stdcall, Enum_Func);
    pragma Machine_Attribute (Enum_Func, "ms_abi");
    function Enum_Func (hDC      : GWindows.Types.Handle;
                        lpHTable : Handle_Table_Access;
                        lpEMFR   : PEMR_Type;
                        nObj     : Integer;
-                       lpData   : EMF_Enum_Proc) return Integer is
+                       lpData   : GWindows.Types.Lparam) return Integer is
       pragma Unreferenced (hDC);
+      function To_EMF_Enum_Proc is
+        new Ada.Unchecked_Conversion (GWindows.Types.Lparam, EMF_Enum_Proc);
+      Proc : constant EMF_Enum_Proc := To_EMF_Enum_Proc (lpData);
    begin
-      lpData (lpEMFR, lpHTable, nObj);
+      Proc (lpEMFR, lpHTable, nObj);
       return 1;
    end Enum_Func;
 
@@ -43,10 +47,12 @@ package body GWindows.Enum_EMF is
                            Enum_Proc : EMF_Enum_Proc;
                            Rect      : GWindows.Types.Rectangle_Type)
                            return Boolean is
+      function To_Lparam is
+        new Ada.Unchecked_Conversion (EMF_Enum_Proc, GWindows.Types.Lparam);
    begin
       return EnumEnhMetaFile (GWindows.Drawing.Handle (Canvas),
                               GWindows.Drawing_EMF.Handle (Emf),
-                              Enum_Func'Access, Enum_Proc,
+                              Enum_Func'Access, To_Lparam (Enum_Proc),
                               Rect'Unrestricted_Access) /= 0;
    end Enumerate_EMF;
 


### PR DESCRIPTION
Fixed a few crashes remaining from wrong win32 api bindings. please confirm no breaks on windows target and also no more crashes on winelib.
Continuation of [Winelib](https://github.com/zertovitch/gwindows/pull/40)