### PR TITLE
winelib: pragma Restrictions (No_Implicit_Dynamic_Code) 

### DIFF
--- a/gwindows/docs/Winelib.txt
+++ b/gwindows/docs/Winelib.txt
@@ -252,6 +252,43 @@ Framework Callback Changes
   framework's own window procedure (Ada-to-Ada), not directly from
   Win32 PE code, so trampolines work fine for them.
 
+  Regression guard
+  ----------------
+
+  gwindows-application.adb and gwindows-common_dialogs.adb carry
+
+      pragma Restrictions (No_Implicit_Dynamic_Code);
+
+  at the top of the body, as a compile-time guard against any future
+  reintroduction of a nested callback registered with a foreign
+  calling convention (StdCall or C).  That is the exact construct
+  that emits a stack trampoline on x86_64 GNAT and crashes under
+  Wine's PE-to-Unix thunks.
+
+  Scope of the check:
+
+    - Catches:  'Access / 'Unrestricted_Access of a nested subprogram
+                whose access type has Convention (Stdcall) or
+                Convention (C).  GNAT must produce a real C-callable
+                function pointer here, which is the trampoline case.
+
+    - Ignores:  'Access of a nested subprogram passed through an
+                Ada access-to-subprogram (default convention).  GNAT
+                uses a fat-pointer descriptor (a two-word data
+                structure tagged in the low bit) instead of a
+                trampoline, so no dynamic code is generated and the
+                restriction does not fire.  This is why the legitimate
+                nested handlers in samples and elsewhere remain valid.
+
+  Recommendation: any new framework unit (or contributed extension)
+  that registers a callback with Win32 — i.e. takes 'Access of an
+  Ada subprogram and hands the address to a Win32 API via an
+  access-to-subprogram with Convention (Stdcall) or Convention (C) —
+  should add the same pragma at the top of its body.  This turns the
+  whole class of "nested-callback-crashes-under-Wine" bugs into a
+  compile-time error, with no runtime cost and no effect on Windows
+  builds.
+
 
 Sample Status
 -------------

--- a/gwindows/framework/gwindows-application.adb
+++ b/gwindows/framework/gwindows-application.adb
@@ -37,6 +37,8 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
+pragma Restrictions (No_Implicit_Dynamic_Code);
+
 with GWindows.GStrings;
 with GWindows.Internal;
 with GWindows.Windows;

--- a/gwindows/framework/gwindows-application.adb
+++ b/gwindows/framework/gwindows-application.adb
@@ -38,6 +38,8 @@
 ------------------------------------------------------------------------------
 
 pragma Restrictions (No_Implicit_Dynamic_Code);
+--  Prevent use of nested callback subprograms: they crash under Linux & Winelib.
+--  You can find more information in gwindows/docs/Winelib.txt, Regression guard.
 
 with GWindows.GStrings;
 with GWindows.Internal;

--- a/gwindows/framework/gwindows-common_dialogs.adb
+++ b/gwindows/framework/gwindows-common_dialogs.adb
@@ -37,6 +37,8 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
+pragma Restrictions (No_Implicit_Dynamic_Code);
+
 with Ada.Unchecked_Conversion;
 with Interfaces.C;
 with GWindows.Application;

--- a/gwindows/framework/gwindows-common_dialogs.adb
+++ b/gwindows/framework/gwindows-common_dialogs.adb
@@ -38,6 +38,8 @@
 ------------------------------------------------------------------------------
 
 pragma Restrictions (No_Implicit_Dynamic_Code);
+--  Prevent use of nested callback subprograms: they crash under Linux & Winelib.
+--  You can find more information in gwindows/docs/Winelib.txt, Regression guard.
 
 with Ada.Unchecked_Conversion;
 with Interfaces.C;


### PR DESCRIPTION
Add `pragma Restrictions (No_Implicit_Dynamic_Code)` at the top of gwindows-application.adb and gwindows-common_dialogs.adb so any future reintroduction of a nested 'Access through a foreign calling convention (StdCall/C) fails at compile time rather than crashing under Wine's PE-to-Unix thunks.

The restriction targets exactly the construct that emits a stack trampoline.  Ada-to-Ada access of nested subprograms is unaffected, since GNAT uses a fat-pointer descriptor (data only) for those.

Added regression guard section to docs/Winelib.txt